### PR TITLE
Allow to definte the element for the intro

### DIFF
--- a/R/introjs.R
+++ b/R/introjs.R
@@ -23,6 +23,7 @@
 #' @param session the Shiny session object (from the server function of the Shiny app)
 #' @param options List of options to be passed to intro.js
 #' @param events List of text that are the body of a Javascript function. Must wrap in [I()]
+#' @param element Element to start the intro on
 #' @note For documentation on intro.js options and events, see \url{https://github.com/usablica/intro.js/wiki/Documentation}.
 #' @seealso [introjsUI()] [introBox()]
 #' @examples
@@ -62,11 +63,12 @@
 
 introjs <- function(session,
                     options = list(),
-                    events = list()) {
-  options <- list(options = options, events = events)
+                    events = list(),
+                    element = NULL) {
+  options <- list(options = options, events = events, element = element)
   session$sendCustomMessage(type = "introjs",
                             message = jsonlite::toJSON(options,
-                                                       auto_unbox = TRUE))
+                                                       auto_unbox = TRUE, null = "null"))
   
 }
 

--- a/inst/javascript/rintro.js
+++ b/inst/javascript/rintro.js
@@ -14,7 +14,12 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 Shiny.addCustomMessageHandler('introjs',function(options) {
-  introJs().setOptions(options.options).oncomplete(function() {
+  if (options.element == null) {
+    var intro = introJs();
+  } else {
+    var intro = introJs(options.element);
+  }
+  intro.setOptions(options.options).oncomplete(function() {
     options.events.hasOwnProperty("oncomplete") && eval(options.events.oncomplete[0]);
     }).onexit(function() {
       options.events.hasOwnProperty("onexit") && eval(options.events.onexit[0]);


### PR DESCRIPTION
#40 

This allows to define the element on which the intro will be startet. In case of a modal dialog, this selector should be `#shiny-modal`.