### PR TITLE
Documentation edits

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,7 +14,7 @@ License: AGPL-3
 LazyData: TRUE
 Imports: shiny, jsonlite
 Depends: R (>= 3.0.0)
-RoxygenNote: 6.1.1
+RoxygenNote: 7.1.0
 URL: https://github.com/carlganz/rintrojs
 BugReports: https://github.com/carlganz/rintrojs/issues
 Suggests: testthat,

--- a/R/introjs.R
+++ b/R/introjs.R
@@ -23,7 +23,7 @@
 #' @param session the Shiny session object (from the server function of the Shiny app)
 #' @param options List of options to be passed to intro.js
 #' @param events List of text that are the body of a Javascript function. Must wrap in [I()]
-#' @note For documentation on intro.js options and events, see \url{https://github.com/usablica/intro.js/wiki/Documentation}.
+#' @note For documentation on intro.js options and events, see \url{https://introjs.com/docs/}.
 #' @seealso [introjsUI()] [introBox()]
 #' @examples
 #' \dontrun{
@@ -53,7 +53,7 @@
 #'   })
 #'   observeEvent(input$btn,
 #'                introjs(session, options = list("nextLabel"="Onwards and Upwards"),
-#'                                 events = list("oncomplete"='alert("It is over")')))
+#'                                 events = list("oncomplete"=I('alert("It is over")'))))
 #' })
 #' # Run the application
 #' shinyApp(ui = ui, server = server)

--- a/man/introBox.Rd
+++ b/man/introBox.Rd
@@ -4,10 +4,14 @@
 \alias{introBox}
 \title{Generate intro elements in UI}
 \usage{
-introBox(..., data.step, data.intro, data.hint,
+introBox(
+  ...,
+  data.step,
+  data.intro,
+  data.hint,
   data.position = c("bottom", "auto", "top", "left", "right", "bottom",
-  "bottom-left_aligned", "bottom-middle-aligned", "bottom-right-aligned",
-  "auto"))
+    "bottom-left_aligned", "bottom-middle-aligned", "bottom-right-aligned", "auto")
+)
 }
 \arguments{
 \item{...}{Elements in introduction element}

--- a/man/introjs.Rd
+++ b/man/introjs.Rd
@@ -20,7 +20,7 @@ hintjs(session, options = list(), events = list())
 Initiates an introduction via the intro.js library
 }
 \note{
-For documentation on intro.js options and events, see \url{https://github.com/usablica/intro.js/wiki/Documentation}.
+For documentation on intro.js options and events, see \url{https://introjs.com/docs/}.
 }
 \examples{
 \dontrun{
@@ -50,7 +50,7 @@ server <- shinyServer(function(input, output, session) {
   })
   observeEvent(input$btn,
                introjs(session, options = list("nextLabel"="Onwards and Upwards"),
-                                events = list("oncomplete"='alert("It is over")')))
+                                events = list("oncomplete"=I('alert("It is over")'))))
 })
 # Run the application
 shinyApp(ui = ui, server = server)


### PR DESCRIPTION
Fixes #45 

Added the missing `I()` in the `introjs()` example. The example now functions as expected. Also updated the introjs documentation link.

Ran `devtools::document()` which resulted in the other file changes.